### PR TITLE
Refresh site nav and lint configuration

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,3 +9,4 @@ ignores:
   - ".devcontainer/**"
   - ".github/**"
   - "WARP.md"
+  - "AGENTS.md"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The site follows the GitHub Pages Jekyll layout. Source markdown lives at the root (`index.md` for the landing page, `about.md` for the profile), while long-form content belongs in `_posts/` using the `YYYY-MM-DD-slug.md` pattern. Global settings sit in `_config.yml` with CI overrides in `_config.ci.yml`. Automation resides under `.github/workflows/`, and formatter settings are tracked in `.editorconfig` and `.markdownlint-cli2.yaml`. Generated output in `_site/` is disposable—never edit it by hand.
+
+## Build, Test, and Development Commands
+- `bundle install` — install Ruby 3.2 dependencies defined in the `Gemfile`.
+- `bundle exec jekyll serve --livereload` — run the site locally at `http://127.0.0.1:4000/my_blog` with hot reload.
+- `bundle exec jekyll build --trace` — create a production build in `_site/` with verbose diagnostics.
+- `bundle exec htmlproofer ./_site --assume-extension --check-html --disable-external` — validate internal links and markup after a build.
+
+## Coding Style & Naming Conventions
+Two-space indentation, LF endings, and trimmed whitespace are enforced via `.editorconfig`. Posts always start with YAML front matter declaring `title` and optional `description`. Stick to GitHub Flavored Markdown (set through kramdown) and keep heading levels consistent. Inline HTML is allowed for complex layouts; pair it with semantic classes from Minima when possible. Reference images from an `assets/` folder and use hyphenated filenames.
+
+## Testing Guidelines
+Mirror CI by running `bundle exec jekyll build --config _config.yml,_config.ci.yml` before checks. Follow up with the html-proofer command above to catch broken anchors or HTML regressions. Markdownlint (`npx markdownlint-cli2 "**/*.md"`) and Lychee link checks both run in GitHub Actions; resolve any warnings locally to keep pipelines green. For new features, add sample content or fixtures under `_posts/` to exercise the changes.
+
+## Commit & Pull Request Guidelines
+Recent history favors sentence-case commit messages with concise imperatives (e.g., `Initialize Jekyll…`). Keep subjects under ~72 characters and add detail in the body when needed. Pull requests should summarize the change, list affected pages, and note `bundle exec jekyll build` + html-proofer results. Include screenshots or GIFs for visual updates and reference issues with `Fixes #ID` so automation can close them on merge.

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,12 @@
-title: "My Blog"
+title: "dennis.kim"
 description: "Thoughts, product notes, and experiments."
 url: "https://denniyahh.github.io"
-baseurl: "/my_blog"
+baseurl: "/"
+
+# Navigation
+header_pages:
+  - index.md
+  - about.md
 
 # Theme
 theme: minima
@@ -26,6 +31,7 @@ exclude:
   - .devcontainer
   - .github
   - README.md
+  - AGENTS.md
   - WARP.md
 
 # Defaults

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: home
-title: Home
+title: Latest Updates
+#list_title: Updates
 ---
 
-Welcome to my blog. New posts will appear below.
+Welcome to my blog. New updates will appear below.


### PR DESCRIPTION
## Summary
- rename home navigation to Updates and reorder header links
- rename site title to dennis.kim and ensure AGENTS.md stays out of builds
- add contributor guide and ignore it in markdownlint (CLI config + ignore file)

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000
- bundle exec jekyll build --config _config.yml,_config.ci.yml

Supersedes #7.